### PR TITLE
fix(nas-monitor): stop argocd reverting runtime state configmap

### DIFF
--- a/gitops/appsets/apps-raw.yaml
+++ b/gitops/appsets/apps-raw.yaml
@@ -107,6 +107,15 @@ spec:
             - .metadata
             - .status
             - .spec.conversion
+        # nas-monitor writes runtime state here; committed manifest seeds "unknown".
+        # Ignore .data.state so ArgoCD doesn't revert the hook's patches (which would
+        # suppress "recovered" alerts and cause duplicate "unreachable" alerts on flap).
+        - group: ""
+          kind: ConfigMap
+          name: nas-monitor-state
+          namespace: monitoring
+          jqPathExpressions:
+            - .data.state
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
## Problem

Today's ntfy alert at 13:45 UTC fired correctly when the Synology DSM web UI briefly timed out (real 5s blip). Synology was reachable again by 13:50, but no "recovered" alert followed. Investigation found a long-standing bug.

The nas-monitor shell-operator hook stores its last-observed state in `ConfigMap/monitoring/nas-monitor-state`, patching `data.state` to `up` or `down` on each check. The committed manifest seeds `state: unknown`. ArgoCD's selfHeal reverts `data.state` to `unknown` on every reconcile.

Observed behavior:

```bash
$ kubectl get cm nas-monitor-state -n monitoring -o jsonpath='{.data.state}'
unknown
```

Pod logs show the patch succeeding immediately before (`configmap/nas-monitor-state patched`), so ArgoCD is reverting it between checks.

## Failure modes

Looking at the script's guards in `gitops/apps/nas-monitor/hooks/nas-monitor.sh`:

```bash
# reachable branch:
if [ "$CURRENT_STATE" != "up" ]; then
  if [ "$CURRENT_STATE" != "unknown" ]; then
    send_alert "NAS Recovered" ...   # ← suppressed when ArgoCD reset state
  fi
  kubectl patch ... state: up
fi
```

1. **Recovery alerts are silently suppressed.** After a down event, ArgoCD reverts to `unknown` before the next check, so the recovery guard never fires.
2. **Duplicate down alerts on flap.** If the device goes down again after ArgoCD has reset state to `unknown`, the `state != down` guard passes and re-fires "unreachable" even though we already alerted for the same incident.

## Fix

Add an appset-wide `ignoreDifferences` rule scoped by name+namespace to `monitoring/nas-monitor-state` / `.data.state`. This lets the hook's runtime writes survive reconcile. The rule only matches that one ConfigMap — all other ConfigMaps across all apps in `apps-raw` stay fully reconciled.

```yaml
- group: ""
  kind: ConfigMap
  name: nas-monitor-state
  namespace: monitoring
  jqPathExpressions:
    - .data.state
```

`RespectIgnoreDifferences=true` is already set in `syncOptions`, so the rule is honored during sync (not just diff display).

## Test plan

- [ ] Sync nas-monitor app
- [ ] Wait for next scheduled check (cron `*/5 * * * *`)
- [ ] `kubectl get cm nas-monitor-state -n monitoring -o jsonpath='{.data.state}'` → `up` (and stays `up`, not reverted)
- [ ] Force a transient failure (stop DSM briefly) and verify only one down alert + one recovery alert fire

## Alternatives considered

- **Move state to emptyDir/annotation**: avoids ArgoCD entirely but loses state on pod restart.
- **Remove seed from manifest**: CM would then be created by the hook's first patch, which fails because patch on non-existent CM errors out. Would need init logic.
- Current: minimal, surgical, scoped.